### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746061036,
-        "narHash": "sha256-OxYwCGJf9VJ2KnUO+w/hVJVTjOgscdDg/lPv8Eus07Y=",
+        "lastModified": 1746152631,
+        "narHash": "sha256-zBuvmL6+CUsk2J8GINpyy8Hs1Zp4PP6iBWSmZ4SCQ/s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3afd19146cac33ed242fc0fc87481c67c758a59e",
+        "rev": "032bc6539bd5f14e9d0c51bd79cfe9a055b094c3",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1746067100,
-        "narHash": "sha256-6JeEbboDvRjLwB9kzCnmWj+f+ZnMtKOe5c2F1VBpaTs=",
+        "lastModified": 1746153335,
+        "narHash": "sha256-vwKelhJJS8haCdH3t8uf96VFao7/YzJahPG5JLTO1PU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "026e8fedefd6b167d92ed04b195c658d95ffc7a5",
+        "rev": "ebc7823c3ffde594c7733113042b72694d996de9",
         "type": "github"
       },
       "original": {
@@ -154,16 +154,15 @@
     "rustowl": {
       "flake": false,
       "locked": {
-        "lastModified": 1746009790,
-        "narHash": "sha256-Bzl9KbhKedk10xTInHW0ckkTZsrRM3nWpZLwwQ0pEqc=",
+        "lastModified": 1746166091,
+        "narHash": "sha256-apJmGTeILroUK7Nff9UAUVht1dry4Cr9nF+SJOIalKE=",
         "owner": "cordx56",
         "repo": "rustowl",
-        "rev": "a71f2aaf1db1e13ac2e8de248359a8f3badaefd5",
+        "rev": "5d629f544b41190874523884e8811da1a59e8356",
         "type": "github"
       },
       "original": {
         "owner": "cordx56",
-        "ref": "v0.3.0",
         "repo": "rustowl",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1746061036,
+        "narHash": "sha256-OxYwCGJf9VJ2KnUO+w/hVJVTjOgscdDg/lPv8Eus07Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "3afd19146cac33ed242fc0fc87481c67c758a59e",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745289264,
-        "narHash": "sha256-7nt+UJ7qaIUe2J7BdnEEph9n2eKEwxUwKS/QIr091uA=",
+        "lastModified": 1746067100,
+        "narHash": "sha256-6JeEbboDvRjLwB9kzCnmWj+f+ZnMtKOe5c2F1VBpaTs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3b7171858c20d5293360042936058fb0c4cb93a9",
+        "rev": "026e8fedefd6b167d92ed04b195c658d95ffc7a5",
         "type": "github"
       },
       "original": {
@@ -154,15 +154,16 @@
     "rustowl": {
       "flake": false,
       "locked": {
-        "lastModified": 1745125557,
-        "narHash": "sha256-O82Hu7EqJ9l8rBEgn1VBTDaXX8dWIGzlD5NYTCX9quY=",
+        "lastModified": 1746009790,
+        "narHash": "sha256-Bzl9KbhKedk10xTInHW0ckkTZsrRM3nWpZLwwQ0pEqc=",
         "owner": "cordx56",
         "repo": "rustowl",
-        "rev": "0765997ac19ce54b7de06fb81cca6aa57e778065",
+        "rev": "a71f2aaf1db1e13ac2e8de248359a8f3badaefd5",
         "type": "github"
       },
       "original": {
         "owner": "cordx56",
+        "ref": "v0.3.0",
         "repo": "rustowl",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rustowl = {
-      url = "github:cordx56/rustowl";
+      url = "github:cordx56/rustowl?ref=v0.3.0";
       flake = false;
     };
     rust-overlay.url = "github:oxalica/rust-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     rustowl = {
-      url = "github:cordx56/rustowl?ref=v0.3.0";
+      url = "github:cordx56/rustowl";
       flake = false;
     };
     rust-overlay.url = "github:oxalica/rust-overlay";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -8,7 +8,7 @@
 
   rustowl-nvim = final.vimUtils.buildVimPlugin {
     pname = "rustowl";
-    version = "${((final.lib.importTOML "${inputs.rustowl}/rustowl/Cargo.toml").package).version}-unstable";
+    version = "${((final.lib.importTOML "${inputs.rustowl}/Cargo.toml").package).version}-unstable";
     src = inputs.rustowl;
   };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -32,7 +32,7 @@ in
     ];
 
     RUSTOWL_TOOLCHAIN = toolchainTOML.toolchain.channel;
-    RUSTOWL_TOOLCHAIN_DIR = "${toolchain}";
+    RUSTOWL_SYSROOTS = "${toolchain}";
 
     meta = with lib; {
       description = "Visualize ownership and lifetimes in Rust for debugging and optimization";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,9 +4,9 @@
   rustowl-src,
   makeRustPlatform,
 }: let
-  toolchain = pkgs.rust-bin.fromRustupToolchainFile "${rustowl-src}/rustowl/rust-toolchain.toml";
-  toolchainTOML = lib.importTOML "${rustowl-src}/rustowl/rust-toolchain.toml";
-  cargoTOML = lib.importTOML "${rustowl-src}/rustowl/Cargo.toml";
+  toolchain = pkgs.rust-bin.fromRustupToolchainFile "${rustowl-src}/rust-toolchain.toml";
+  toolchainTOML = lib.importTOML "${rustowl-src}/rust-toolchain.toml";
+  cargoTOML = lib.importTOML "${rustowl-src}/Cargo.toml";
   rustPlatform = makeRustPlatform {
     cargo = toolchain;
     rustc = toolchain;
@@ -18,14 +18,17 @@ in
 
     src = rustowl-src;
 
-    sourceRoot = "source/rustowl";
-
     cargoDeps = rustPlatform.importCargoLock {
-      lockFile = "${src}/rustowl/Cargo.lock";
+      lockFile = "${src}/Cargo.lock";
     };
 
     nativeBuildInputs = [
       toolchain
+      pkgs.pkg-config
+    ];
+
+    buildInputs = [
+      pkgs.openssl
     ];
 
     RUSTOWL_TOOLCHAIN = toolchainTOML.toolchain.channel;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,13 +22,13 @@ in
       lockFile = "${src}/Cargo.lock";
     };
 
-    nativeBuildInputs = [
+    nativeBuildInputs = with pkgs; [
       toolchain
-      pkgs.pkg-config
+      pkg-config
     ];
 
-    buildInputs = [
-      pkgs.openssl
+    buildInputs = with pkgs; [
+      openssl
     ];
 
     RUSTOWL_TOOLCHAIN = toolchainTOML.toolchain.channel;


### PR DESCRIPTION
v0.3.0 is locked at this stage due to a compilation dependency failure issue with the latest commit in rustowl.