### PR TITLE
Add zlib for darwin

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,9 +27,13 @@ in
       pkg-config
     ];
 
-    buildInputs = with pkgs; [
-      openssl
-    ];
+    buildInputs = with pkgs;
+      [
+        openssl
+      ]
+      ++ lib.optionals stdenv.isDarwin [
+        zlib
+      ];
 
     RUSTOWL_TOOLCHAIN = toolchainTOML.toolchain.channel;
     RUSTOWL_SYSROOTS = "${toolchain}";


### PR DESCRIPTION
In my darwin environment, rustowl cannot build.

```
   Compiling tower-lsp v0.20.0
error: linking with `/nix/store/7vyr5q4p1hb9ya1d7zsgikdfzbzjmk4c-clang-wrapper-19.1.7/bin/cc` failed: ex
it status: 1
  |
  = note:  "/nix/store/7vyr5q4p1hb9ya1d7zsgikdfzbzjmk4c-clang-wrapper-19.1.7/bin/cc" "/private/tmp/nix-b
uild-rustowl-0.3.2-unstable.drv-0/rustcwbE3gn/symbols.o" "<1 object files omitted>" "/private/tmp/nix-bu
ild-rustowl-0.3.2-unstable.drv-0/rustcwbE3gn/{libtikv_jemalloc_sys-d44c3833be0d4506.rlib,libring-a3d0b04
10cb3cace.rlib}.rlib" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/librustc_driver-77d6b58b688beb15.d
ylib" "/nix/store/gl1s4z2ajj706y6n11mj9gvjzj1835jh-rust-std-1.88.0-nightly-2025-04-08-aarch64-apple-darw
in/lib/rustlib/aarch64-apple-darwin/lib/{libcompiler_builtins-3c1b8593a3f1e67c.rlib}.rlib" "-liconv" "-l
m" "-lz" "-lc++" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.3.0" "-L" "/p
rivate/tmp/nix-build-rustowl-0.3.2-unstable.drv-0/source/target/aarch64-apple-darwin/release/build/ring-
f3ffbedda53139bc/out" "-L" "/private/tmp/nix-build-rustowl-0.3.2-unstable.drv-0/source/target/aarch64-ap
ple-darwin/release/build/tikv-jemalloc-sys-34130f8d41be5fa4/out/build/lib" "-L" "/private/tmp/nix-build-
rustowl-0.3.2-unstable.drv-0/source/target/aarch64-apple-darwin/release/build/bzip2-sys-b69eaa0d3f325a07
/out/lib" "-L" "/private/tmp/nix-build-rustowl-0.3.2-unstable.drv-0/source/target/aarch64-apple-darwin/r
elease/build/lzma-sys-13f35db751e08279/out" "-L" "/private/tmp/nix-build-rustowl-0.3.2-unstable.drv-0/so
urce/target/aarch64-apple-darwin/release/build/zstd-sys-8010b478da6e3f9d/out" "-o" "/private/tmp/nix-bui
ld-rustowl-0.3.2-unstable.drv-0/source/target/aarch64-apple-darwin/release/deps/rustowlc-7b8339f057347e3
a" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: library not found for -lz
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `rustowl` (bin "rustowlc") due to 1 previous error
```

This pr fix these error by adding zlib package.

tested environment
```
 - system: `"aarch64-darwin"`
 - host os: `Darwin 24.4.0, macOS 15.4.1`
 - multi-user?: `yes`
 - sandbox: `no`
 - version: `nix-env (Nix) 2.24.12`
 - nixpkgs: `/nix/store/crrwsv142k1vkwdba7q26y73760n4bll-source`
```
