### PR TITLE
fix: link the sysroot under the toolchain name embedded by build.rs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -48,6 +48,10 @@ in
         $out/bin/rustowlc \
         $out/bin/sysroot/${RUSTOWL_TOOLCHAIN}/bin/rustowlc
     '';
+    postFixup = ''
+      # prevent rustowl from falling back to a downloaded toolchain
+      ln -sfn ${RUSTOWL_SYSROOTS} $out/bin/sysroot/${RUSTUP_TOOLCHAIN}
+    '';
     meta = with lib; {
       description = "Visualize ownership and lifetimes in Rust for debugging and optimization";
       longDescription = ''


### PR DESCRIPTION
Follow-up to #419 / #421.

`build.rs` embeds `RUSTUP_TOOLCHAIN` as the sysroot directory name, for example `1.97.0-nightly-2026-04-16`. `postInstall` installs the directory as `RUSTOWL_TOOLCHAIN`, for example `nightly-2026-04-16`. The names never match. So the binary ignores the packaged sysroot and downloads a toolchain to `~/.rustowl` at runtime.

The downloaded `cargo` does not run on NixOS without nix-ld. `rustowl/cursor` then returns `status = "error"` and shows no highlighting.

Link `RUSTOWL_SYSROOTS` under the embedded name. This keeps every lookup in the nix store.