### PR TITLE
fix: use host platform for Darwin check

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -36,7 +36,7 @@ in
       [
         openssl
       ]
-      ++ lib.optionals stdenv.isDarwin [
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
         zlib
       ];
 


### PR DESCRIPTION
Replace the deprecated stdenv compatibility alias so RustOwl evaluates without a warning.

@mrcjkb 